### PR TITLE
Improve try_parse error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,14 +140,14 @@ impl Formatter {
     pub fn parse(&self, value: &str) -> f64 {
         let v: Vec<&str> = value.split(&self.separator).collect();
 
-        let result = v.get(0).unwrap().parse::<f64>().unwrap();
+        let result = v.first().unwrap().parse::<f64>().unwrap();
 
         let mut suffix = v.get(1).unwrap().to_string();
         let new_len = suffix.len() - self.forced_units.len();
 
         suffix.truncate(new_len);
 
-        let magnitude_multiplier = self.scales.get_magnitude_multipler(&suffix);
+        let magnitude_multiplier = self.scales.get_magnitude_multiplier(&suffix);
 
         result * magnitude_multiplier
     }
@@ -174,13 +174,9 @@ impl Formatter {
 
         let result = number.parse::<f64>().map_err(|e| e.to_string())?;
 
-        let magnitude_multiplier = self.scales.get_magnitude_multipler(&suffix);
+        let magnitude_multiplier = self.scales.try_get_magnitude_multiplier(&suffix)?;
 
-        if magnitude_multiplier > 0.0 {
-            Ok(result * magnitude_multiplier)
-        } else {
-            Err(format!("Unknown suffix: {}", suffix))
-        }
+        Ok(result * magnitude_multiplier)
     }
 }
 
@@ -254,7 +250,31 @@ impl Scales {
         self
     }
 
-    fn get_magnitude_multipler(&self, value: &str) -> f64 {
+    fn try_get_magnitude_multiplier(&self, value: &str) -> Result<f64, String> {
+        self.suffixes
+            .iter()
+            .enumerate()
+            .find_map(|(idx, x)| {
+                if value == x {
+                    Some((self.base as f64).powi(idx as i32))
+                } else {
+                    None
+                }
+            })
+            .ok_or_else(|| {
+                format!(
+                    "Unknown suffix: {value}, valid suffixes are: {}",
+                    self.suffixes
+                        .iter()
+                        .filter(|x| !x.trim().is_empty())
+                        .map(String::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            })
+    }
+
+    fn get_magnitude_multiplier(&self, value: &str) -> f64 {
         for ndx in 0..self.suffixes.len() {
             if value == self.suffixes[ndx] {
                 return (self.base as f64).powi(ndx as i32);


### PR DESCRIPTION
If `get_magnitude_multiplier` cannot find a matching entry in `suffixes`, it returns `0.0`.
This is then used as a failure case in `try_parse` to specify a mismatched suffix.

This is not clear to end users what the specific mismatch was, and what the valid cases are.

Create a new method `try_get_magnitude_multiplier` that returns a more explicit error in this case.

In addition, fix mispelling of the `get_magnitude_multiplier` method.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>
